### PR TITLE
error handling for smbclient yielding no OS info

### DIFF
--- a/enum4linux.pl
+++ b/enum4linux.pl
@@ -460,8 +460,14 @@ sub get_os_info {
 	my $os_info = `$command`;
 	chomp $os_info;
 	if (defined($os_info)) {
-		($os_info) = $os_info =~ /(Domain=[^\n]+)/s;
-		print "[+] Got OS info for $global_target from smbclient: $os_info\n";
+		my $os_info_result;
+		($os_info_result) = $os_info =~ /(Domain=[^\n]+)/s;
+		if (defined($os_info_result)) {
+			print "[+] Got OS info for $global_target from smbclient: $os_info_result\n";
+		}
+		else {
+			print "[E] smbclient returned no or invalid OS info for $global_target: \"$os_info\"\n";
+		}
 	}
 
 	$command = "rpcclient -W '$global_workgroup' -U'$global_username'\%'$global_password' -c 'srvinfo' '$global_target' 2>&1";


### PR DESCRIPTION
Handle an error where smbclient yields no OS info. This is a longstanding bug in some versions of smbclient, see for example: https://bugs.kali.org/view.php?id=5739

Output before:
```
 =================================== 
|    OS information on 10.2.2.15    |
 =================================== 
Use of uninitialized value $os_info in concatenation (.) or string at ./enum4linux.pl line 464.
[+] Got OS info for 10.2.2.15 from smbclient: 
[+] Got OS info for 10.2.2.15 from srvinfo:
Cannot connect to server.  Error was NT_STATUS_IO_TIMEOUT
```

Output after:
```
 =================================== 
|    OS information on 10.2.2.15    |
 =================================== 
[E] smbclient returned no or invalid OS info for 10.2.2.15: ""
[+] Got OS info for 10.2.2.15 from srvinfo:
Cannot connect to server.  Error was NT_STATUS_IO_TIMEOUT
```